### PR TITLE
fix download_db() to use correct unzip wrt has_pass

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -32,7 +32,7 @@ download_db <- function(force = FALSE, passphrase = NULL) {
   if (!file.exists(tgt)) {
     if (!dir.exists(dirname(tgt))) dir.create(dirname(tgt), recursive = TRUE)
     message("... unpacking ", temp, " to ", tgt)
-    if (has_pass) {
+    if (!has_pass) {
       R.utils::bunzip2(filename = temp, destname = tgt)
     } else {
       rcrypt::decrypt(temp, passphrase = passphrase, output = tgt)


### PR DESCRIPTION
Hi @mskyttner,

Thanks for this awesome R package! I noticed this minor issue when initially trying to run `download_db()`, per the [intro vignette](https://raquamaps.github.io/aquamapsdata/articles/intro.html). It successfully downloaded https://archive.org/download/aquamapsdb/am.db.bz2 into the temp file location, but ran the wrong method `rcrypt::decrypt()` for `has_pass` to unpack it into the target :

```r
    if (has_pass) {
      R.utils::bunzip2(filename = temp, destname = tgt)
    } else {
      rcrypt::decrypt(temp, passphrase = passphrase, output = tgt)
    } 
```

Output:
```
Download of aquamapsdb (https://archive.org/download/aquamapsdb/am.db.bz2 -> /var/folders/2r/grqvdjfn04361tzk8mh60st40000gn/T/am.db.bz2 -> /Users/bbest/Library/Application Support/aquamaps/am.db)
 [100%] Downloaded 1249240020 bytes...
... unpacking /var/folders/2r/grqvdjfn04361tzk8mh60st40000gn/T/am.db.bz2 to /Users/bbest/Library/Application Support/aquamaps/am.db
gpg: Note: '--decrypt' is not considered an option
gpg: directory '/Users/bbest/.gnupg' created
gpg: keybox '/Users/bbest/.gnupg/pubring.kbx' created
gpg: WARNING: no command supplied.  Trying to guess what you mean ...
usage: gpg [options] [filename]
done
```

Simply adding a negation `!has_pass` should fix this:

```r
    if (!has_pass) {
      R.utils::bunzip2(filename = temp, destname = tgt)
    } else {
      rcrypt::decrypt(temp, passphrase = passphrase, output = tgt)
    } 
```
